### PR TITLE
Do not lock assemblies - use shadow copy and then load assemblies

### DIFF
--- a/Functions/YamlDotNet-Integration.Tests.ps1
+++ b/Functions/YamlDotNet-Integration.Tests.ps1
@@ -3,6 +3,21 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$here\YamlDotNet-Integration.ps1"
 Load-YamlDotNetLibraries "$here\..\Libs"
 
+Describe "Load-YamlDotNetLibraries" {
+
+	$yamldotNet = "$here\..\Libs\YamlDotNet.Core.dll"
+    $yamldotNetTempName = "$here\..\Libs\YamlDotNet.Core.Temp.dll"
+	
+    It "should not lock the assembly files" {
+		Copy-Item $yamldotNet  $yamldotNetTempName
+		Remove-Item $yamldotNet
+		Copy-Item $yamldotNetTempName $yamldotNet  -force
+		Remove-Item $yamldotNetTempName
+		$result = Test-Path $yamldotNet
+		$result.should.be($true)
+    }
+}
+
 Describe "Convert-YamlScalarNodeToValue" {
 
     It "takes a YamlScalar and converts it to a value type" {

--- a/Functions/YamlDotNet-Integration.ps1
+++ b/Functions/YamlDotNet-Integration.ps1
@@ -1,5 +1,26 @@
 function Load-YamlDotNetLibraries([string] $dllPath) {
-    gci $dllPath | % { [Reflection.Assembly]::LoadFrom($_.FullName) } | Out-Null
+    #gci $dllPath | % { [Reflection.Assembly]::LoadFrom($_.FullName) } | Out-Null
+	
+	#one could go about this in two ways
+	#1. load files into memory as a byte array and override assembly resolve and when it is one of these just use the ones in memory.
+	# [system.appdomain]::CurrentDomain.AssemblyResolve
+	#https://github.com/chucknorris/roundhouse/blob/master/product/roundhouse.databases.mysql/MySqlAdoNetProviderResolver.cs#L41
+	
+    # $dlls = gci $dllPath 
+	# foreach ($dll in $dlls) {
+		# $fileStream = ([System.IO.FileInfo] (Get-Item $dll.FullName)).OpenRead();
+		# $assemblyBytes = new-object byte[] $fileStream.Length
+		# $fileStream.Read($assemblyBytes, 0, $fileStream.Length);
+		# $fileStream.Close();
+		# [System.Reflection.Assembly]::Load($assemblyBytes);
+	# }
+
+	#2. shadow copy
+	$dllTempPath = Join-Path $env:Temp (Join-Path 'poweryaml' 'assemblies')
+	if (!(Test-Path($dllTempPath))) { [System.IO.Directory]::CreateDirectory($dllTempPath) }
+	gci $dllPath | % { Copy-Item $_.FullName $dllTempPath} | Out-Null
+    gci $dllTempPath | % { [Reflection.Assembly]::LoadFrom($_.FullName) } | Out-Null
+	
 }
 
 function Get-YamlStream([string] $file) {


### PR DESCRIPTION
Hey @scottmuc - I wanted to get something in place that keeps the files from being locked. I went for the cheap route for now (shadow copy assemblies). 

Having this in place will allow me to use it with choco.
